### PR TITLE
FETCH_OWNER_RECORDS: owner records api implemented

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 def jooq_version = '3.19.16'
-def mapstructVer = '1.6.2'
+def mapstructVer = '1.6.3'
 def liquibaseVer = '3.5.5'
 
 group = 'com.tlback'
@@ -37,9 +37,11 @@ dependencies {
 	}
 	implementation 'io.swagger.core.v3:swagger-annotations:2.2.15'
 
+	// utils
 	implementation "org.mapstruct:mapstruct:${mapstructVer}"
 	annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVer}"
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	// ---
 
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:junit-jupiter'

--- a/deploy-db.sh
+++ b/deploy-db.sh
@@ -7,7 +7,6 @@ DB_PORT="${2:-5599}"
 DB_PASS="${3:-postgres}"
 DB_USER="${4:-postgres}"
 
-
 echo "Deploying database:"
 echo "Db name: $DB_NAME"
 echo "Db port: $DB_PORT"

--- a/src/main/java/com/tlback/dao/jooq/JooqRecordRepository.java
+++ b/src/main/java/com/tlback/dao/jooq/JooqRecordRepository.java
@@ -1,0 +1,62 @@
+package com.tlback.dao.jooq;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jooq.DSLContext;
+import org.jooq.SelectOnConditionStep;
+import org.springframework.stereotype.Service;
+
+import com.tlback.dao.jooq.tools.RxUtils;
+import com.tlback.domain.RecordEntity;
+import com.tlback.jooq.gen.tables.Record;
+import com.tlback.jooq.gen.tables.RecordPending;
+import com.tlback.jooq.gen.tables.User;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class JooqRecordRepository {
+    private static final com.tlback.jooq.gen.tables.Record recordTable = Record.RECORD;
+    private static final RecordPending recordPendingTable = RecordPending.RECORD_PENDING;
+    private static final User userTable = User.USER;
+
+    private final DSLContext dsl;
+
+    public Flux<RecordEntity> findByDateAndServiceOwner(
+            Long serviceOwnerId,
+            Long dateStart,
+            Long dateEnd,
+            Optional<Boolean> isPublic) {
+        var query = fetch(dsl)
+                .where(recordTable.RECORD_OWNER_ID.eq(serviceOwnerId));
+                // .and(recordTable.TIME_FROM.greaterThan(dateStart))
+                // .and(recordTable.TIME_TO.lessThan(dateEnd));
+
+        if (isPublic.isPresent())
+            query = query.and(recordTable.IS_PUBLIC.eq(isPublic.get()));
+
+        return RxUtils.fluxIterable(query, it -> {
+            Map<Long, RecordEntity> records = new HashMap<>();
+            it.forEach(rec -> {
+                var record = records.computeIfAbsent(rec.get(recordTable.ID),
+                        k -> rec.into(recordTable.fields()).into(RecordEntity.class));
+                var pending = rec.into(recordPendingTable.fields())
+                        .into(com.tlback.domain.RecordPending.class);
+                if (pending.getPendingOwner() == null)
+                    pending.setPendingOwner(rec.into(userTable.fields()).into(com.tlback.domain.UserEntity.class));
+                record.getRecordPendings().add(pending);
+            });
+            return records.values();
+        });
+    }
+
+    public static SelectOnConditionStep<org.jooq.Record> fetch(DSLContext dsl) {
+        return dsl.select().from(recordTable)
+                .join(recordPendingTable).on(recordTable.ID.eq(recordPendingTable.RECORD_ID))
+                .join(userTable).on(recordPendingTable.CLIENT_ID.eq(userTable.ID));
+    }
+}

--- a/src/main/java/com/tlback/domain/RecordEntity.java
+++ b/src/main/java/com/tlback/domain/RecordEntity.java
@@ -1,5 +1,8 @@
 package com.tlback.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
@@ -34,4 +37,5 @@ public class RecordEntity {
     @Column("time_to")
     private Long timeTo;
 
+    private List<RecordPending> recordPendings = new ArrayList<>();
 }

--- a/src/main/java/com/tlback/domain/RecordPending.java
+++ b/src/main/java/com/tlback/domain/RecordPending.java
@@ -1,6 +1,7 @@
 package com.tlback.domain;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -13,11 +14,20 @@ import lombok.NoArgsConstructor;
 public class RecordPending {
 
     @Id
-    private RecordPendingPk pk;
+    @Transient
+    private transient RecordPendingPk id;
+
+    @Column("client_id")
+    private Long clientId;
+
+    @Column("record_id")
+    private Long recordId;
 
     @Column("request_time")
     private Long requestTime;
 
     @Column("confirmed")
     private Boolean confirmed;
+
+    private UserEntity pendingOwner;
 }

--- a/src/main/java/com/tlback/service/RecordService.java
+++ b/src/main/java/com/tlback/service/RecordService.java
@@ -1,0 +1,22 @@
+package com.tlback.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.tlback.dao.jooq.JooqRecordRepository;
+import com.tlback.domain.RecordEntity;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class RecordService {
+    private final JooqRecordRepository recordRepository;
+
+    public Flux<RecordEntity> getOwnerRecords(Long userId) {
+        return recordRepository.findByDateAndServiceOwner(userId, /*TODO */null, /*TODO */null,
+            Optional.empty());
+    }
+}

--- a/src/main/java/com/tlback/web/dto/OwnerRecordPendingDto.java
+++ b/src/main/java/com/tlback/web/dto/OwnerRecordPendingDto.java
@@ -1,0 +1,30 @@
+package com.tlback.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class OwnerRecordPendingDto implements Comparable<OwnerRecordPendingDto> {
+
+    @JsonProperty(value = "request_time")
+    private Long requestTime;
+
+    @JsonProperty(value = "confirmed")
+    private Boolean confirmed;
+
+    @JsonProperty(value = "requester_id")
+    private Long requesterId;
+
+    @JsonProperty(value = "requester_login")
+    private String requesterLogin;
+
+    @Override
+    public int compareTo(OwnerRecordPendingDto o) {
+        if (this.requestTime == null || o.getRequestTime() == null)
+            return 0;
+        return this.requestTime.compareTo(o.getRequestTime());
+    }
+}

--- a/src/main/java/com/tlback/web/dto/ServiceOwnerRecordDto.java
+++ b/src/main/java/com/tlback/web/dto/ServiceOwnerRecordDto.java
@@ -1,0 +1,38 @@
+package com.tlback.web.dto;
+
+import java.util.SortedSet;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ServiceOwnerRecordDto {
+
+    private Long id;
+
+    @JsonProperty(value = "service_info_id")
+    private Long serviceInfoId;
+
+    @JsonProperty(value = "record_owner_id")
+    private Long recordOwnerId;
+
+    @JsonProperty(value = "is_public")
+    private Boolean isPublic;
+
+    @JsonProperty(value = "limit")
+    private Integer limit;
+
+    @JsonProperty(value = "time_from")
+    private Long timeFrom;
+
+    @JsonProperty(value = "time_to")
+    private Long timeTo;
+
+    @JsonProperty(value = "record_pendings")
+    private SortedSet<OwnerRecordPendingDto> recordPendings;
+}

--- a/src/main/java/com/tlback/web/mapper/RecordMapper.java
+++ b/src/main/java/com/tlback/web/mapper/RecordMapper.java
@@ -1,0 +1,13 @@
+package com.tlback.web.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import com.tlback.domain.RecordEntity;
+import com.tlback.web.dto.ServiceOwnerRecordDto;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = {RecordPendingMapper.class})
+public interface RecordMapper {
+
+    ServiceOwnerRecordDto toDto(RecordEntity entity);
+}

--- a/src/main/java/com/tlback/web/mapper/RecordPendingMapper.java
+++ b/src/main/java/com/tlback/web/mapper/RecordPendingMapper.java
@@ -1,0 +1,24 @@
+package com.tlback.web.mapper;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+
+import com.tlback.domain.RecordPending;
+import com.tlback.web.dto.OwnerRecordPendingDto;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public abstract class RecordPendingMapper {
+    
+    @Mapping(target = "requesterLogin", source = "pendingOwner.login")
+    @Mapping(target = "requesterId", source = "pendingOwner.id")
+    public abstract OwnerRecordPendingDto toDto(RecordPending recordPending);
+
+    public SortedSet<OwnerRecordPendingDto> toDto(SortedSet<RecordPending> recordPendings) {
+        return recordPendings.stream().map(this::toDto)
+            .collect(() -> new TreeSet<>(), SortedSet::add, SortedSet::addAll);
+    }
+}

--- a/src/main/java/com/tlback/web/rest/HomeResource.java
+++ b/src/main/java/com/tlback/web/rest/HomeResource.java
@@ -8,16 +8,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tlback.domain.view.ServiceInfoView;
+import com.tlback.service.RecordService;
 import com.tlback.service.ServiceInfoService;
 import com.tlback.service.UserService;
+import com.tlback.web.dto.ServiceOwnerRecordDto;
 import com.tlback.web.dto.UserDto;
+import com.tlback.web.mapper.RecordMapper;
 import com.tlback.web.mapper.UserMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 
 
 @RestController
@@ -27,7 +29,11 @@ import reactor.core.publisher.Mono;
 public class HomeResource {
     private final UserService userService;
     private final UserMapper mapper;
+
     private final ServiceInfoService serviceInfo;
+
+    private final RecordService recordService;
+    private final RecordMapper recordMapper;
 
     @PostMapping("/create")
     public Mono<UserDto> postMethodName(@RequestBody UserDto userDto) {
@@ -38,6 +44,11 @@ public class HomeResource {
     @GetMapping("/get-user")
     public Mono<UserDto> getRecords(@RequestParam(name = "user_id") Long userId) {
         return userService.findById(userId).map(it -> mapper.toDto(it));
+    }
+
+    @GetMapping("/get-owner-records")
+    public Flux<ServiceOwnerRecordDto> getOwnerRecords(@RequestParam(name = "user_id") Long userId) {
+        return recordService.getOwnerRecords(userId).map(it -> recordMapper.toDto(it));
     }
 
     @GetMapping("/get-service-info")

--- a/src/main/resources/db/sql/d01_mock-data.sql
+++ b/src/main/resources/db/sql/d01_mock-data.sql
@@ -4,12 +4,43 @@
 INSERT INTO role ("id", "name") VALUES (1, 'ROLE_USER');
 INSERT INTO role ("id", "name") VALUES (2, 'ROLE_ADM');
 
-INSERT INTO "user" ("id", "name", "last_name", "middle_name", "login") VALUES (1, 'Igor', 'Abobenko', 'Makadamov', 'IgroLoh');
+INSERT INTO "user" ("id", "name", "last_name", "middle_name", "login")
+    VALUES (1, 'Igor', 'Abobenko', 'Makadamov', 'IgroLoh');
+
+INSERT INTO "user" ("id", "name", "last_name", "middle_name", "login")
+    VALUES (2, 'Shavel', 'Oreshnik', 'Femozov', 'shavel@228');
+
+INSERT INTO "user" ("id", "name", "last_name", "middle_name", "login")
+    VALUES (3, 'Zina', 'Kravtsova', 'Zhukova', 'zinka@ymerla');
 
 INSERT INTO "user_role" ("user_id", "role_id") VALUES (1, 1);
 INSERT INTO "user_role" ("user_id", "role_id") VALUES (1, 2);
 
 INSERT INTO "service_info" ("id", "service_name", "service_owner_id", "editable", "service_description", "record_limit", "time_duration")
     VALUES (1, 'test_resnichkee', 1, true, 'test', 1, 1);
-INSERT INTO "record" ("id", "service_info_id", "record_owner_id", "is_public", "limit", "time_from", "time_to") VALUES (1, 1, 1, false, 1, 123123, 1231500);
-INSERT INTO "record" ("id", "service_info_id", "record_owner_id", "is_public", "limit", "time_from", "time_to") VALUES (2, 1, 1, true, 1, 123500, 123600);
+
+--- records
+INSERT INTO "record" ("id", "service_info_id", "record_owner_id", "is_public", "limit", "time_from", "time_to")
+    VALUES (1, 1, 1, false, 1, 123123, 1231500);
+
+INSERT INTO "record" ("id", "service_info_id", "record_owner_id", "is_public", "limit", "time_from", "time_to")
+    VALUES (2, 1, 1, true, 1, 123500, 123600);
+
+INSERT INTO "record" ("id", "service_info_id", "record_owner_id", "is_public", "limit", "time_from", "time_to")
+    VALUES (3, 1, 1, true, 1, 123600, 123700);
+--- /records
+
+--- record_pending
+INSERT INTO "record_pending" ("record_id", "client_id", "request_time", "confirmed")
+    VALUES (1, 2, 123, false);
+INSERT INTO "record_pending" ("record_id", "client_id", "request_time", "confirmed")
+    VALUES (1, 3, 124, false);
+
+INSERT INTO "record_pending" ("record_id", "client_id", "request_time", "confirmed")
+    VALUES (2, 2, 1235, true);
+INSERT INTO "record_pending" ("record_id", "client_id", "request_time", "confirmed")
+    VALUES (2, 3, 1236, false);
+
+INSERT INTO "record_pending" ("record_id", "client_id", "request_time", "confirmed")
+    VALUES (3, 3, 123500, false);
+--- /record_pending


### PR DESCRIPTION
- Add utils dependency for MapStruct.
- Remove unnecessary echo command in deploy-db.sh script.
- Modify RecordEntity and RecordPending classes, adding new fields and annotations.
- Refactor HomeResource controller, adding new methods and imports.
- Update mock data in d01_mock-data.sql.