### PR TITLE
HOTFIX/FIX_CI: The changes to the GitHub Actions workflow appear to i…

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches-ignore: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches-ignore: [ "main" ]
 
 jobs:
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'com.diffplug.eclipse.apt' version '4.3.0'
   	id 'eclipse'
 
+	id 'org.springframework.boot' version '3.4.1' apply false
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.springframework.boot' version '3.4.1'
 }
 
 allprojects {
@@ -69,4 +69,16 @@ configure tlcore, {
 // Develop configs
 task generateEclipseConfig {
   	dependsOn 'cleanEclipse', ':tl-core:generateJooq', 'eclipse', 'eclipseJdt', 'eclipseJdtApt'
+}
+
+task bootJar(type: Copy) {
+    dependsOn ':tl-core:bootJar'
+    from("$rootDir/tl-core/build/libs/") {
+        include '*.jar'
+    }
+    into "$rootDir/build/libs"
+    rename { String fileName ->
+        // Переименовать jar, чтобы было понятно, что это root-jar
+        fileName.replace('tl-core', rootProject.name)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,3 @@ configure tlcore, {
 task generateEclipseConfig {
   	dependsOn 'cleanEclipse', ':tl-core:generateJooq', 'eclipse', 'eclipseJdt', 'eclipseJdtApt'
 }
-
-bootJar {
-	mainClass = 'com.tlback.core.TlbackApplication'
-}

--- a/tl-core/build.gradle
+++ b/tl-core/build.gradle
@@ -122,5 +122,5 @@ tasks.named('test') {
 }
 
 bootJar {
-	mainClass = 'com.tlback.core.TlbackApplication'
+	mainClassName = 'com.tlback.core.TlbackApplication'
 }

--- a/tl-core/build.gradle
+++ b/tl-core/build.gradle
@@ -120,3 +120,7 @@ jooq {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+bootJar {
+	mainClass = 'com.tlback.core.TlbackApplication'
+}


### PR DESCRIPTION
…nvert the trigger conditions unintentionally, which could disable CI/CD for the `main` branch. Here's the analysis:

**Problem:**
- **Original Behavior:** The workflow triggers on pushes and pull requests targeting the `main` branch. ```yaml on: push: branches: [ "main" ] pull_request: branches: [ "main" ] ```
- **After Change:** Using `branches-ignore: [ "main" ]` makes the workflow **exclude** the `main` branch. It will now run for pushes/PRs on **all branches except `main`**, which is likely the opposite of the intended behavior.

**Recommendation:**
- To retain the original behavior (trigger only on `main`), revert to using `branches` instead of `branches-ignore`.
- If the goal was to **exclude** `main` (e.g., run CI on other branches), the current changes are correct, but this is unusual for typical workflows where `main` is the primary branch for CI.

**Fix (revert to original behavior):**
```diff
on:
  push:
-   branches-ignore: [ "main" ]
+   branches: [ "main" ]
  pull_request:
-   branches-ignore: [ "main" ]
+   branches: [ "main" ]
```

If excluding `main` was intentional, consider adding comments to explain the reasoning to avoid confusion.